### PR TITLE
ROC2 - Add unit tests

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -38,5 +38,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "jest-canvas-mock": "^2.5.2"
   }
 }

--- a/examples/src/App.test.js
+++ b/examples/src/App.test.js
@@ -2,8 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 
-it('renders without crashing', () => {
+test('renders App without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(App, div);
+  ReactDOM.unmountComponentAtNode(div);
+});
+
+test('contains a react-org-chart div', () => {
   const div = document.createElement('div');
   ReactDOM.render(<App />, div);
+  expect(div.innerHTML).toContain('<div id=\"react-org-chart\"></div>');
   ReactDOM.unmountComponentAtNode(div);
 });

--- a/examples/src/setupTests.js
+++ b/examples/src/setupTests.js
@@ -1,0 +1,1 @@
+import 'jest-canvas-mock';


### PR DESCRIPTION
- Added a simple test that checks if react-org-chart div is present. I wanted to do more but I don't have time and want to go forward with the update of the codebase
- Fixed the error `Error: Not implemented: HTMLCanvasElement.prototype.getContext` that appeared after running `npm run test` in the example code. Found the monkey patch [here](https://stackoverflow.com/questions/48458334/functions-are-not-valid-as-a-react-child-this-may-happen-if-you-return-a-compon)